### PR TITLE
v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class Api::RootController < ApiController
   self.extra_actions = {test: :get}
 
   def root
-    return api_response(
+    render_api(
       {
         message: "Welcome to the API.",
         how_to_authenticate: <<~END.lines.map(&:strip).join(" "),
@@ -88,7 +88,7 @@ class Api::RootController < ApiController
   end
 
   def test
-    return api_response({message: "Hello, world!"})
+    render_api({message: "Hello, world!"})
   end
 end
 ```
@@ -105,7 +105,7 @@ class Api::MoviesController < ApiController
   def first
     # Always use the bang method, since the framework will rescue `RecordNotFound` and return a
     # sensible error response.
-    return api_response(self.get_records.first!)
+    render_api(self.get_records.first!)
   end
 
   def get_recordset

--- a/app/views/rest_framework/routes_and_forms/_html_form.html.erb
+++ b/app/views/rest_framework/routes_and_forms/_html_form.html.erb
@@ -3,7 +3,7 @@
     <label class="form-label w-100">Route
       <select class="form-control form-control-sm" id="htmlFormRoute">
         <% @_rrf_form_routes_html.each do |route| %>
-          <% path = @route_props[:with_path_args].call(route[:route]) %>
+          <% path = route[:path_with_params] %>
           <option value="<%= route[:verb] %>:<%= path %>"><%= route[:verb] %> <%= route[:relative_path] %></option>
         <% end %>
       </select>
@@ -21,16 +21,16 @@
     <% controller.get_fields.map(&:to_s).each do |f| %>
       <%
         # Don't provide form fields for associations or primary keys.
-        metadata = controller.class.fields_metadata[f]
-        next if !metadata || metadata[:kind] == "association" || metadata[:read_only]
+        cfg = controller.class.field_configuration[f]
+        next if !cfg || cfg[:kind] == "association" || cfg[:readonly]
       %>
       <div class="mb-2">
-        <% if metadata[:kind] == "rich_text" %>
+        <% if cfg[:kind] == "rich_text" %>
           <label class="form-label w-100"><%= controller.class.label_for(f) %></label>
           <%= form.rich_text_area f %>
-        <% elsif metadata[:kind] == "attachment" %>
+        <% elsif cfg[:kind] == "attachment" %>
           <label class="form-label w-100"><%= controller.class.label_for(f) %>
-            <%= form.file_field f, multiple: metadata.dig(:attachment, :macro) == :has_many_attached %>
+            <%= form.file_field f, multiple: cfg[:attachment_type] == :has_many_attached %>
           </label>
         <% else %>
           <label class="form-label w-100"><%= controller.class.label_for(f) %>

--- a/app/views/rest_framework/routes_and_forms/_raw_form.html.erb
+++ b/app/views/rest_framework/routes_and_forms/_raw_form.html.erb
@@ -3,7 +3,7 @@
     <label class="form-label w-100">Route
       <select class="form-control form-control-sm" id="rawFormRoute">
         <% @_rrf_form_routes_raw.each do |route| %>
-          <% path = @route_props[:with_path_args].call(route[:route]) %>
+          <% path = route[:path_with_params] %>
           <option
             value="<%= route[:verb] %>:<%= path %>"
             data-supports-files="<%= !route[:action].in?(["update_all", "destroy", "destroy_all"]) ? "true" : "" %>"

--- a/app/views/rest_framework/routes_and_forms/routes/_route.html.erb
+++ b/app/views/rest_framework/routes_and_forms/routes/_route.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td>
     <% if route[:verb] == "GET" && route[:matches_params] %>
-      <%= link_to route[:relative_path], @route_props[:with_path_args].call(route[:route]) %>
+      <%= link_to route[:relative_path], route[:path_with_params] %>
     <% else %>
       <%= route[:relative_path] %>
     <% end %>

--- a/guide/2_controllers/index.md
+++ b/guide/2_controllers/index.md
@@ -57,10 +57,11 @@ A fundamental feature that REST Framework provides is the ability to render a br
 allows developers to discover and interact with the API's functionality, while also providing faster
 and more lightweight JSON/XML formats for consumption by the systems these developers create.
 
-The `api_response` method is how this is accomplished. The first argument is the data to be
-rendered (often an array or hash), and keyword arguments can be provided to customize the response
-(e.g., setting the HTTP status code). Using this method instead of the classic Rails helpers, such
-as `render`, will automatically provide the browsable API as well as JSON/XML rendering.
+The `render_api` method is how this is accomplished. Note that this was called `render_api` prior
+to v1, and it is still aliased to provide backwards compatibility. The first argument is the data to
+be rendered (often an array or hash), and keyword arguments can be provided to customize the
+response (e.g., setting the HTTP status code). Using this method instead of the classic `render`
+will automatically provide the browsable API as well as JSON/XML rendering.
 
 Here is a simple example of rendering a hash with a `message` key:
 
@@ -70,7 +71,7 @@ class ApiController < ApplicationController
   self.extra_actions = {test: :get}
 
   def test
-    api_response({message: "Test successful!"})
+    render_api({message: "Test successful!"})
   end
 end
 ```
@@ -86,7 +87,7 @@ class ApiController < ApplicationController
   self.extra_actions = {test: :get}
 
   def test
-    api_response({message: "Test successful!"})
+    render_api({message: "Test successful!"})
   end
 end
 ```
@@ -99,7 +100,7 @@ class ApiController < ApplicationController
   self.extra_actions = {test: [:get, :post]}
 
   def test
-    api_response({message: "Test successful!"})
+    render_api({message: "Test successful!"})
   end
 end
 ```
@@ -115,7 +116,7 @@ class ApiController < ApplicationController
   self.extra_actions = {test_action: {path: :test, methods: :get}}
 
   def test_action
-    api_response({message: "Test successful!"})
+    render_api({message: "Test successful!"})
   end
 end
 ```
@@ -196,7 +197,7 @@ class Api::MoviesController < ApiController
     # REST Framework will rescue ActiveRecord::RecordInvalid or ActiveRecord::RecordNotSaved.
     @record.update!(enabled: false)
 
-    return api_response(@record)
+    render_api(@record)
   end
 end
 ```

--- a/guide/4_filtering_and_ordering/index.md
+++ b/guide/4_filtering_and_ordering/index.md
@@ -3,8 +3,7 @@
 While you can control the recordset that the API exposes, sometimes you want the user to control the
 records they want to see, or the order of those records. Both filtering and ordering are
 accomplished through a generic mechanism called "filters". To control the filter backends that a
-controller uses, you can either adjust the `filter_backends` controller attribute or you can
-override the `get_filter_backends()` method.
+controller uses, you can set the `filter_backends` attribute.
 
 ## QueryFilter
 

--- a/lib/rest_framework/errors.rb
+++ b/lib/rest_framework/errors.rb
@@ -3,5 +3,5 @@ end
 
 require_relative "errors/base_error"
 
-require_relative "errors/nil_passed_to_api_response_error"
+require_relative "errors/nil_passed_to_render_api_error"
 require_relative "errors/unknown_model_error"

--- a/lib/rest_framework/errors/nil_passed_to_render_api_error.rb
+++ b/lib/rest_framework/errors/nil_passed_to_render_api_error.rb
@@ -1,7 +1,7 @@
-class RESTFramework::Errors::NilPassedToAPIResponseError < RESTFramework::Errors::BaseError
+class RESTFramework::Errors::NilPassedToRenderAPIError < RESTFramework::Errors::BaseError
   def message
     return <<~MSG.split("\n").join(" ")
-      Payload of `nil` was passed to `api_response`; this is unsupported. If you want a blank
+      Payload of `nil` was passed to `render_api`; this is unsupported. If you want a blank
       response, pass `''` (an empty string) as the payload. If this was the result of a `find_by`
       (or similar Active Record method) not finding a record, you should use the bang version (e.g.,
       `find_by!`) to raise `ActiveRecord::RecordNotFound`, which the REST controller will catch and
@@ -11,4 +11,4 @@ class RESTFramework::Errors::NilPassedToAPIResponseError < RESTFramework::Errors
 end
 
 # Alias for convenience.
-RESTFramework::NilPassedToAPIResponseError = RESTFramework::Errors::NilPassedToAPIResponseError
+RESTFramework::NilPassedToRenderAPIError = RESTFramework::Errors::NilPassedToRenderAPIError

--- a/lib/rest_framework/filters/ordering_filter.rb
+++ b/lib/rest_framework/filters/ordering_filter.rb
@@ -2,16 +2,16 @@
 class RESTFramework::Filters::OrderingFilter < RESTFramework::Filters::BaseFilter
   # Get a list of ordering fields for the current action.
   def _get_fields
-    return @controller.ordering_fields&.map(&:to_s) || @controller.get_fields
+    return @controller.class.ordering_fields&.map(&:to_s) || @controller.get_fields
   end
 
   # Convert ordering string to an ordering configuration.
   def _get_ordering
-    return nil if @controller.ordering_query_param.blank?
+    return nil unless param = @controller.class.ordering_query_param.presence
 
     # Ensure ordering_fields are strings since the split param will be strings.
     fields = self._get_fields
-    order_string = @controller.params[@controller.ordering_query_param]
+    order_string = @controller.params[param]
 
     if order_string.present?
       ordering = {}.with_indifferent_access
@@ -40,7 +40,7 @@ class RESTFramework::Filters::OrderingFilter < RESTFramework::Filters::BaseFilte
   # Order data according to the request query parameters.
   def filter_data(data)
     ordering = self._get_ordering
-    reorder = !@controller.ordering_no_reorder
+    reorder = !@controller.class.ordering_no_reorder
 
     if ordering && !ordering.empty?
       return data.send(reorder ? :reorder : :order, ordering)

--- a/lib/rest_framework/filters/ordering_filter.rb
+++ b/lib/rest_framework/filters/ordering_filter.rb
@@ -52,6 +52,3 @@ end
 
 # Alias for convenience.
 RESTFramework::OrderingFilter = RESTFramework::Filters::OrderingFilter
-
-# TODO: Compatibility; remove in 1.0.
-RESTFramework::ModelOrderingFilter = RESTFramework::Filters::OrderingFilter

--- a/lib/rest_framework/filters/query_filter.rb
+++ b/lib/rest_framework/filters/query_filter.rb
@@ -22,7 +22,7 @@ class RESTFramework::Filters::QueryFilter < RESTFramework::Filters::BaseFilter
         field, sub_field = match[1..2]
         next false unless field.in?(fields)
 
-        sub_fields = @controller.class.field_config_for(field)[:sub_fields] || []
+        sub_fields = @controller.class.field_configuration[field][:sub_fields] || []
         if sub_field.in?(sub_fields)
           includes << field.to_sym
           next true

--- a/lib/rest_framework/filters/query_filter.rb
+++ b/lib/rest_framework/filters/query_filter.rb
@@ -66,6 +66,3 @@ end
 
 # Alias for convenience.
 RESTFramework::QueryFilter = RESTFramework::Filters::QueryFilter
-
-# TODO: Compatibility; remove in 1.0.
-RESTFramework::ModelQueryFilter = RESTFramework::Filters::QueryFilter

--- a/lib/rest_framework/filters/ransack_filter.rb
+++ b/lib/rest_framework/filters/ransack_filter.rb
@@ -2,13 +2,13 @@
 class RESTFramework::Filters::RansackFilter < RESTFramework::Filters::BaseFilter
   # Filter data according to the request query parameters.
   def filter_data(data)
-    q = @controller.request.query_parameters[@controller.ransack_query_param]
+    q = @controller.request.query_parameters[@controller.class.ransack_query_param]
 
     if q.present?
-      distinct = @controller.ransack_distinct
+      distinct = @controller.class.ransack_distinct
 
       # Determine if `distinct` is determined by query param.
-      if distinct_query_param = @controller.ransack_distinct_query_param
+      if distinct_query_param = @controller.class.ransack_distinct_query_param
         if distinct_query = @controller.request.query_parameters[distinct_query_param].presence
           distinct_from_query = ActiveRecord::Type::Boolean.new.cast(distinct_query)
           unless distinct_from_query.nil?
@@ -17,7 +17,7 @@ class RESTFramework::Filters::RansackFilter < RESTFramework::Filters::BaseFilter
         end
       end
 
-      return data.ransack(q, @controller.ransack_options || {}).result(distinct: distinct)
+      return data.ransack(q, @controller.class.ransack_options || {}).result(distinct: distinct)
     end
 
     return data

--- a/lib/rest_framework/filters/search_filter.rb
+++ b/lib/rest_framework/filters/search_filter.rb
@@ -41,6 +41,3 @@ end
 
 # Alias for convenience.
 RESTFramework::SearchFilter = RESTFramework::Filters::SearchFilter
-
-# TODO: Compatibility; remove in 1.0.
-RESTFramework::ModelSearchFilter = RESTFramework::Filters::SearchFilter

--- a/lib/rest_framework/filters/search_filter.rb
+++ b/lib/rest_framework/filters/search_filter.rb
@@ -1,7 +1,7 @@
 class RESTFramework::Filters::SearchFilter < RESTFramework::Filters::BaseFilter
   # Get a list of search fields for the current action.
   def _get_fields
-    if search_fields = @controller.search_fields
+    if search_fields = @controller.class.search_fields
       return search_fields&.map(&:to_s)
     end
 
@@ -13,7 +13,7 @@ class RESTFramework::Filters::SearchFilter < RESTFramework::Filters::BaseFilter
 
   # Filter data according to the request query parameters.
   def filter_data(data)
-    search = @controller.request.query_parameters[@controller.search_query_param]
+    search = @controller.request.query_parameters[@controller.class.search_query_param]
 
     if search.present?
       if fields = self._get_fields.presence
@@ -28,7 +28,7 @@ class RESTFramework::Filters::SearchFilter < RESTFramework::Filters::BaseFilter
         # Ensure we pass user input as arguments to prevent SQL injection.
         return data.where(
           fields.map { |f|
-            "CAST(#{f} AS #{data_type}) #{@controller.search_ilike ? "ILIKE" : "LIKE"} ?"
+            "CAST(#{f} AS #{data_type}) #{@controller.class.search_ilike ? "ILIKE" : "LIKE"} ?"
           }.join(" OR "),
           *(["%#{search}%"] * fields.length),
         )

--- a/lib/rest_framework/mixins/base_controller_mixin.rb
+++ b/lib/rest_framework/mixins/base_controller_mixin.rb
@@ -133,18 +133,13 @@ module RESTFramework::Mixins::BaseControllerMixin
     end
   end
 
-  def serializer_class
-    # TODO: Compatibility; remove in 1.0.
-    if klass = self.try(:get_serializer_class)
-      return klass
-    end
-
+  def get_serializer_class
     return self.class.serializer_class
   end
 
   # Serialize the given data using the `serializer_class`.
   def serialize(data, **kwargs)
-    return RESTFramework::Utils.wrap_ams(self.serializer_class).new(
+    return RESTFramework::Utils.wrap_ams(self.get_serializer_class).new(
       data, controller: self, **kwargs
     ).serialize
   end

--- a/lib/rest_framework/mixins/base_controller_mixin.rb
+++ b/lib/rest_framework/mixins/base_controller_mixin.rb
@@ -240,7 +240,7 @@ module RESTFramework::Mixins::BaseControllerMixin
   end
 
   # TODO: Might make this the default render method in the future.
-  alias_method :render_api, :render_api
+  alias_method :api_response, :render_api
 
   def openapi_metadata
     response_content_types = [

--- a/lib/rest_framework/mixins/base_controller_mixin.rb
+++ b/lib/rest_framework/mixins/base_controller_mixin.rb
@@ -152,7 +152,7 @@ module RESTFramework::Mixins::BaseControllerMixin
       400
     end
 
-    return api_response(
+    render_api(
       {
         message: e.message,
         errors: e.try(:record).try(:errors),
@@ -174,11 +174,11 @@ module RESTFramework::Mixins::BaseControllerMixin
     xml_kwargs = kwargs.delete(:xml_kwargs) || {}
 
     # Raise helpful error if payload is nil. Usually this happens when a record is not found (e.g.,
-    # when passing something like `User.find_by(id: some_id)` to `api_response`). The caller should
+    # when passing something like `User.find_by(id: some_id)` to `render_api`). The caller should
     # actually be calling `find_by!` to raise ActiveRecord::RecordNotFound and allowing the REST
     # framework to catch this error and return an appropriate error response.
     if payload.nil?
-      raise RESTFramework::NilPassedToAPIResponseError
+      raise RESTFramework::NilPassedToRenderAPIError
     end
 
     # If `payload` is an `ActiveRecord::Relation` or `ActiveRecord::Base`, then serialize it.
@@ -240,7 +240,7 @@ module RESTFramework::Mixins::BaseControllerMixin
   end
 
   # TODO: Might make this the default render method in the future.
-  alias_method :api_response, :render_api
+  alias_method :render_api, :render_api
 
   def openapi_metadata
     response_content_types = [
@@ -313,7 +313,7 @@ module RESTFramework::Mixins::BaseControllerMixin
   end
 
   def options
-    return api_response(self.openapi_metadata)
+    render_api(self.openapi_metadata)
   end
 end
 

--- a/lib/rest_framework/mixins/base_controller_mixin.rb
+++ b/lib/rest_framework/mixins/base_controller_mixin.rb
@@ -168,7 +168,7 @@ module RESTFramework::Mixins::BaseControllerMixin
 
   # Render a browsable API for `html` format, along with basic `json`/`xml` formats, and with
   # support or passing custom `kwargs` to the underlying `render` calls.
-  def api_response(payload, **kwargs)
+  def render_api(payload, **kwargs)
     html_kwargs = kwargs.delete(:html_kwargs) || {}
     json_kwargs = kwargs.delete(:json_kwargs) || {}
     xml_kwargs = kwargs.delete(:xml_kwargs) || {}
@@ -240,7 +240,7 @@ module RESTFramework::Mixins::BaseControllerMixin
   end
 
   # TODO: Might make this the default render method in the future.
-  alias_method :render_api, :api_response
+  alias_method :api_response, :render_api
 
   def openapi_metadata
     response_content_types = [

--- a/lib/rest_framework/mixins/bulk_model_controller_mixin.rb
+++ b/lib/rest_framework/mixins/bulk_model_controller_mixin.rb
@@ -14,7 +14,7 @@ module RESTFramework::Mixins::BulkCreateModelMixin
     if params[:_json].is_a?(Array)
       records = self.create_all!
       serialized_records = self.bulk_serialize(records)
-      return api_response(serialized_records)
+      return render_api(serialized_records)
     end
 
     return super
@@ -36,7 +36,7 @@ module RESTFramework::Mixins::BulkUpdateModelMixin
   def update_all
     records = self.update_all!
     serialized_records = self.bulk_serialize(records)
-    return api_response(serialized_records)
+    render_api(serialized_records)
   end
 
   # Perform the `update` call and return the collection of (possibly) updated records.
@@ -62,10 +62,10 @@ module RESTFramework::Mixins::BulkDestroyModelMixin
     if params[:_json].is_a?(Array)
       records = self.destroy_all!
       serialized_records = self.bulk_serialize(records)
-      return api_response(serialized_records)
+      return render_api(serialized_records)
     end
 
-    return api_response(
+    render_api(
       {message: "Bulk destroy requires an array of primary keys as input."},
       status: 400,
     )

--- a/lib/rest_framework/mixins/bulk_model_controller_mixin.rb
+++ b/lib/rest_framework/mixins/bulk_model_controller_mixin.rb
@@ -4,10 +4,10 @@ require_relative "model_controller_mixin"
 # the existing `create` action to support bulk creation.
 module RESTFramework::Mixins::BulkCreateModelMixin
   # While bulk update/destroy are obvious because they create new router endpoints, bulk create
-  # overloads the existing collection `POST` endpoint, so we add a special key to the options
+  # overloads the existing collection `POST` endpoint, so we add a special key to the OpenAPI
   # metadata to indicate bulk create is supported.
-  def options_metadata
-    return super.merge({bulk_create: true})
+  def openapi_metadata
+    return super.merge({"x-rrf-bulk-create": true})
   end
 
   def create

--- a/lib/rest_framework/mixins/model_controller_mixin.rb
+++ b/lib/rest_framework/mixins/model_controller_mixin.rb
@@ -349,9 +349,9 @@ module RESTFramework::Mixins::BaseModelControllerMixin
           model = self.class.get_model
 
           if model.method(action).parameters.last&.first == :keyrest
-            return api_response(model.send(action, **params))
+            return render_api(model.send(action, **params))
           else
-            return api_response(model.send(action))
+            return render_api(model.send(action))
           end
         end
       end
@@ -365,9 +365,9 @@ module RESTFramework::Mixins::BaseModelControllerMixin
           record = self.get_record
 
           if record.method(action).parameters.last&.first == :keyrest
-            return api_response(record.send(action, **params))
+            return render_api(record.send(action, **params))
           else
-            return api_response(record.send(action))
+            return render_api(record.send(action))
           end
         end
       end
@@ -691,7 +691,7 @@ end
 # Mixin for listing records.
 module RESTFramework::Mixins::ListModelMixin
   def index
-    return api_response(self.get_index_records)
+    return render_api(self.get_index_records)
   end
 
   # Get records with both filtering and pagination applied.
@@ -719,14 +719,14 @@ end
 # Mixin for showing records.
 module RESTFramework::Mixins::ShowModelMixin
   def show
-    return api_response(self.get_record)
+    return render_api(self.get_record)
   end
 end
 
 # Mixin for creating records.
 module RESTFramework::Mixins::CreateModelMixin
   def create
-    return api_response(self.create!, status: :created)
+    return render_api(self.create!, status: :created)
   end
 
   # Perform the `create!` call and return the created record.
@@ -738,7 +738,7 @@ end
 # Mixin for updating records.
 module RESTFramework::Mixins::UpdateModelMixin
   def update
-    return api_response(self.update!)
+    return render_api(self.update!)
   end
 
   # Perform the `update!` call and return the updated record.
@@ -753,7 +753,7 @@ end
 module RESTFramework::Mixins::DestroyModelMixin
   def destroy
     self.destroy!
-    return api_response("")
+    return render_api("")
   end
 
   # Perform the `destroy!` call and return the destroyed (and frozen) record.

--- a/lib/rest_framework/mixins/model_controller_mixin.rb
+++ b/lib/rest_framework/mixins/model_controller_mixin.rb
@@ -443,7 +443,7 @@ module RESTFramework::Mixins::BaseModelControllerMixin
     )
   end
 
-  # Get a list of parameters allowed for the current action.
+  # Get a hash of strong parameters for the current action.
   def get_allowed_parameters
     return @_get_allowed_parameters if defined?(@_get_allowed_parameters)
 
@@ -510,7 +510,7 @@ module RESTFramework::Mixins::BaseModelControllerMixin
     return super || RESTFramework::NativeSerializer
   end
 
-  # Use strong parameters to filter the request body using the configured allowed parameters.
+  # Use strong parameters to filter the request body.
   def get_body_params(bulk_mode: nil)
     data = self.request.request_parameters
     pk = self.class.get_model&.primary_key
@@ -619,7 +619,7 @@ module RESTFramework::Mixins::BaseModelControllerMixin
     return nil
   end
 
-  # Get the records this controller has access to *after* any filtering is applied.
+  # Filter the recordset and return records this request has access to.
   def get_records
     data = self.get_recordset
 
@@ -628,8 +628,7 @@ module RESTFramework::Mixins::BaseModelControllerMixin
     } || data
   end
 
-  # Get a single record by primary key or another column, if allowed. The return value is memoized
-  # and exposed to the view as the `@record` instance variable.
+  # Get a single record by primary key or another column, if allowed.
   def get_record
     return @record if @record
 

--- a/lib/rest_framework/mixins/model_controller_mixin.rb
+++ b/lib/rest_framework/mixins/model_controller_mixin.rb
@@ -683,11 +683,9 @@ module RESTFramework::Mixins::BaseModelControllerMixin
     # the serializer directly. This would fail for active model serializers, but maybe we don't
     # care?
     s = RESTFramework::Utils.wrap_ams(self.get_serializer_class)
-    serialized_records = records.map do |record|
+    return records.map do |record|
       s.new(record, controller: self).serialize.merge!({errors: record.errors.presence}.compact)
     end
-
-    return serialized_records
   end
 end
 

--- a/lib/rest_framework/mixins/model_controller_mixin.rb
+++ b/lib/rest_framework/mixins/model_controller_mixin.rb
@@ -125,47 +125,12 @@ module RESTFramework::Mixins::BaseModelControllerMixin
       return input_fields
     end
 
-    # Get a field's config, including defaults.
-    def field_config_for(f)
-      f = f.to_sym
-      @_field_config_for ||= {}
-      return @_field_config_for[f] if @_field_config_for[f]
+    # Get a full field configuration, including defaults and inferred values.
+    def field_configuration
+      return @field_configuration if @field_configuration
 
-      config = self.field_config&.dig(f) || {}
-
-      # Default sub-fields if field is an association.
-      if ref = self.get_model.reflections[f.to_s]
-        if ref.polymorphic?
-          columns = {}
-        else
-          model = ref.klass
-          columns = model.columns_hash
-        end
-        config[:sub_fields] ||= RESTFramework::Utils.sub_fields_for(ref)
-        config[:sub_fields] = config[:sub_fields].map(&:to_s)
-
-        # Serialize very basic metadata about sub-fields.
-        config[:sub_fields_metadata] = config[:sub_fields].map { |sf|
-          v = {}
-
-          if columns[sf]
-            v[:kind] = "column"
-          end
-
-          next [sf, v]
-        }.to_h.compact.presence
-      end
-
-      return @_field_config_for[f] = config.compact
-    end
-
-    # Get metadata about the resource's fields.
-    def fields_metadata
-      return @_fields_metadata if @_fields_metadata
-
-      # Get metadata sources.
+      field_config = self.field_config&.with_indifferent_access || {}
       model = self.get_model
-      fields = self.get_fields.map(&:to_s)
       columns = model.columns_hash
       column_defaults = model.column_defaults
       reflections = model.reflections
@@ -177,61 +142,55 @@ module RESTFramework::Mixins::BaseModelControllerMixin
         .select { |n| n.to_s.start_with?("rich_text_") }
       attachment_reflections = model.attachment_reflections
 
-      return @_fields_metadata = fields.map { |f|
-        # Initialize metadata to make the order consistent.
-        metadata = {
-          type: nil,
-          kind: nil,
-          label: self.label_for(f),
-          primary_key: nil,
-          required: nil,
-          read_only: nil,
-        }
+      return @field_configuration = self.get_fields.map { |f|
+        cfg = field_config[f]&.dup || {}
+        cfg[:label] ||= self.label_for(f)
 
-        # Determine `primary_key` based on model.
+        # Annotate primary key.
         if model.primary_key == f
-          metadata[:primary_key] = true
-        end
+          cfg[:primary_key] = true
 
-        # Determine if the field is a read-only attribute.
-        if metadata[:primary_key] || f.in?(readonly_attributes) || f.in?(exclude_body_fields)
-          metadata[:read_only] = true
-        end
-
-        # Determine `type`, `required`, `label`, and `kind` based on schema.
-        if column = columns[f]
-          metadata[:kind] = "column"
-          metadata[:type] = column.type
-          metadata[:required] = true unless column.null
-        end
-
-        # Determine `default` based on schema; we use `column_defaults` rather than `columns_hash`
-        # because these are casted to the proper type.
-        column_default = column_defaults[f]
-        unless column_default.nil?
-          metadata[:default] = column_default
-        end
-
-        # Extract details from the model's attributes hash.
-        if attributes.key?(f) && attribute = attributes[f]
-          unless metadata.key?(:default)
-            default = attribute.value_before_type_cast
-            metadata[:default] = default unless default.nil?
+          unless cfg.key?(:readonly)
+            cfg[:readonly] = true
           end
-          metadata[:kind] ||= "attribute"
+        end
+
+        # Annotate readonly attributes.
+        if f.in?(readonly_attributes) || f.in?(exclude_body_fields)
+          cfg[:readonly] = true
+        end
+
+        # Annotate column data.
+        if column = columns[f]
+          cfg[:kind] = "column"
+          cfg[:type] ||= column.type
+          cfg[:required] = true unless column.null
+        end
+
+        # Add default values from the model's schema.
+        if column_default = column_defaults[f] && !cfg[:default].nil?
+          cfg[:default] ||= column_default
+        end
+
+        # Add metadata from the model's attributes hash.
+        if attribute = attributes[f]
+          if cfg[:default].nil? && default = attribute.value_before_type_cast
+            cfg[:default] = default
+          end
+          cfg[:kind] ||= "attribute"
 
           # Get any type information from the attribute.
           if type = attribute.type
-            metadata[:type] ||= type.type
+            cfg[:type] ||= type.type if type.type
 
             # Get enum variants.
             if type.is_a?(ActiveRecord::Enum::EnumType)
-              metadata[:enum_variants] = type.send(:mapping)
+              cfg[:enum_variants] = type.send(:mapping)
 
-              # Custom integration with `translate_enum`.
+              # TranslateEnum Integration:
               translate_method = "translated_#{f.pluralize}"
               if model.respond_to?(translate_method)
-                metadata[:enum_translations] = model.send(translate_method)
+                cfg[:enum_translations] = model.send(translate_method)
               end
             end
           end
@@ -239,53 +198,65 @@ module RESTFramework::Mixins::BaseModelControllerMixin
 
         # Get association metadata.
         if ref = reflections[f]
-          metadata[:kind] = "association"
+          cfg[:kind] = "association"
+
+          # Determine sub-fields for associations.
+          if ref.polymorphic?
+            ref_columns = {}
+          else
+            ref_columns = ref.klass.columns_hash
+          end
+          cfg[:sub_fields] ||= RESTFramework::Utils.sub_fields_for(ref)
+          cfg[:sub_fields] = cfg[:sub_fields].map(&:to_s)
+
+          # Very basic metadata about sub-fields.
+          cfg[:sub_fields_metadata] = cfg[:sub_fields].map { |sf|
+            v = {}
+
+            if ref_columns[sf]
+              v[:kind] = "column"
+            else
+              v[:kind] = "method"
+            end
+
+            next [sf, v]
+          }.to_h.compact.presence
 
           # Determine if we render id/ids fields. Unfortunately, `has_one` does not provide this
           # interface.
-          if self.permit_id_assignment && id_field = RESTFramework::Utils.get_id_field(f, ref)
-            metadata[:id_field] = id_field
+          if self.permit_id_assignment && id_field = RESTFramework::Utils.id_field_for(f, ref)
+            cfg[:id_field] = id_field
           end
 
           # Determine if we render nested attributes options.
           if self.permit_nested_attributes_assignment && (
             nested_opts = model.nested_attributes_options[f.to_sym].presence
           )
-            metadata[:nested_attributes_options] = {field: "#{f}_attributes", **nested_opts}
+            cfg[:nested_attributes_options] = {field: "#{f}_attributes", **nested_opts}
           end
 
           begin
-            pk = ref.active_record_primary_key
+            cfg[:association_pk] = ref.active_record_primary_key
           rescue ActiveRecord::UnknownPrimaryKey
           end
-          metadata[:association] = {
-            macro: ref.macro,
-            collection: ref.collection?,
-            class_name: ref.class_name,
-            foreign_key: ref.foreign_key,
-            primary_key: pk,
-            polymorphic: ref.polymorphic?,
-            table_name: ref.polymorphic? ? nil : ref.table_name,
-            options: ref.options.as_json.presence,
-          }.compact
+
+          cfg[:reflection] = ref
         end
 
         # Determine if this is an ActionText "rich text".
         if :"rich_text_#{f}".in?(rich_text_association_names)
-          metadata[:kind] = "rich_text"
+          cfg[:kind] = "rich_text"
         end
 
         # Determine if this is an ActiveStorage attachment.
         if ref = attachment_reflections[f]
-          metadata[:kind] = "attachment"
-          metadata[:attachment] = {
-            macro: ref.macro,
-          }
+          cfg[:kind] = "attachment"
+          cfg[:attachment_type] = ref.macro
         end
 
         # Determine if this is just a method.
-        if !metadata[:kind] && model.method_defined?(f)
-          metadata[:kind] = "method"
+        if !cfg[:kind] && model.method_defined?(f)
+          cfg[:kind] = "method"
         end
 
         # Collect validator options into a hash on their type, while also updating `required` based
@@ -299,7 +270,7 @@ module RESTFramework::Mixins::BaseModelControllerMixin
           next if IGNORE_VALIDATORS_WITH_KEYS.any? { |k| options.key?(k) }
 
           # Update `required` if we find a presence validator.
-          metadata[:required] = true if kind == :presence
+          cfg[:required] = true if kind == :presence
 
           # Resolve procs (and lambdas), and symbols for certain arguments.
           if options[:in].is_a?(Proc)
@@ -308,27 +279,65 @@ module RESTFramework::Mixins::BaseModelControllerMixin
             options = options.merge(in: model.send(options[:in]))
           end
 
-          metadata[:validators] ||= {}
-          metadata[:validators][kind] ||= []
-          metadata[:validators][kind] << options
+          cfg[:validators] ||= {}
+          cfg[:validators][kind] ||= []
+          cfg[:validators][kind] << options
         end
 
-        # Serialize any field config.
-        metadata[:config] = self.field_config_for(f).presence
-
-        next [f, metadata.compact]
-      }.to_h
+        next [f, cfg]
+      }.to_h.with_indifferent_access
     end
 
-    # Get a hash of metadata to be rendered in the `OPTIONS` response.
-    def options_metadata
-      return super.merge(
-        {
-          primary_key: self.get_model.primary_key,
-          fields: self.fields_metadata,
-          callbacks: self._process_action_callbacks.as_json,
-        },
-      )
+    def openapi_schema
+      return @openapi_schema if @openapi_schema
+
+      field_configuration = self.field_configuration
+      @openapi_schema = {
+        required: field_configuration.select { |_, cfg| cfg[:required] }.keys,
+        type: "object",
+        properties: field_configuration.map { |f, cfg|
+          v = {title: cfg[:label]}
+
+          if cfg[:kind] == "association"
+            v[:type] = cfg[:reflection].collection? ? "array" : "object"
+          elsif cfg[:kind] == "rich_text"
+            v[:type] = "string"
+            v[:"x-rrf-rich_text"] = true
+          elsif cfg[:kind] == "attachment"
+            v[:type] = "string"
+            v[:"x-rrf-attachment"] = cfg[:attachment_type]
+          else
+            v[:type] = cfg[:type]
+          end
+
+          v[:readOnly] = true if cfg[:readonly]
+          v[:default] = cfg[:default] if cfg.key?(:default)
+
+          if enum_variants = cfg[:enum_variants]
+            v[:enum] = enum_variants.keys
+            v[:"x-rrf-enum_variants"] = enum_variants
+          end
+
+          if validators = cfg[:validators]
+            v[:"x-rrf-validators"] = validators
+          end
+
+          v[:"x-rrf-kind"] = cfg[:kind] if cfg[:kind]
+
+          if cfg[:reflection]
+            v[:"x-rrf-reflection"] = cfg[:reflection]
+            v[:"x-rrf-association_pk"] = cfg[:association_pk]
+            v[:"x-rrf-sub_fields"] = cfg[:sub_fields]
+            v[:"x-rrf-sub_fields_metadata"] = cfg[:sub_fields_metadata]
+            v[:"x-rrf-id_field"] = cfg[:id_field]
+            v[:"x-rrf-nested_attributes_options"] = cfg[:nested_attributes_options]
+          end
+
+          next [f, v]
+        }.to_h,
+      }
+
+      return @openapi_schema
     end
 
     def setup_delegation
@@ -402,13 +411,42 @@ module RESTFramework::Mixins::BaseModelControllerMixin
     end
   end
 
-  # Get a list of fields for this controller.
   def get_fields
     return self.class.get_fields(input_fields: self.class.fields)
   end
 
-  def options_metadata
-    return self.class.options_metadata
+  def openapi_metadata
+    data = super
+    routes = self.route_groups.values[0]
+    schema_name = routes[0][:controller].camelize.gsub("::", ".")
+
+    # Insert schema into metadata.
+    data[:components] ||= {}
+    data[:components][:schemas] ||= {}
+    data[:components][:schemas][schema_name] = self.class.openapi_schema
+
+    # Reference schema for specific actions with a `requestBody`.
+    data[:paths].each do |_path, actions|
+      actions.each do |_method, action|
+        next unless action.is_a?(Hash)
+
+        injectables = [action.dig(:requestBody, :content), *action[:responses].values.map { |r|
+          r[:content]
+        }].compact
+        injectables.each do |i|
+          i.each do |_, v|
+            v[:schema] = {"$ref" => "#/components/schemas/#{schema_name}"}
+          end
+        end
+      end
+    end
+
+    return data.merge(
+      {
+        "x-rrf-primary_key" => self.class.get_model.primary_key,
+        "x-rrf-callbacks" => self._process_action_callbacks.as_json,
+      },
+    )
   end
 
   # Get a list of parameters allowed for the current action.
@@ -442,28 +480,29 @@ module RESTFramework::Mixins::BaseModelControllerMixin
         next nil
       end
 
-      # Return field if it's not an association.
-      next f unless ref = reflections[f]
-
-      # Add `_id`/`_ids` variations for associations.
-      if self.permit_id_assignment && id_field = RESTFramework::Utils.get_id_field(f, ref)
-        if id_field.ends_with?("_ids")
-          hash_variations[id_field] = []
-        else
-          variations << id_field
+      if self.class.field_configuration[f][:reflection]
+        # Add `_id`/`_ids` variations for associations.
+        if self.permit_id_assignment && id_field = self.class.field_configuration[f][:id_field]
+          if id_field.ends_with?("_ids")
+            hash_variations[id_field] = []
+          else
+            variations << id_field
+          end
         end
+
+        # Add `_attributes` variations for associations.
+        if self.permit_nested_attributes_assignment
+          hash_variations["#{f}_attributes"] = (
+            self.class.field_configuration[f][:sub_fields] + ["_destroy"]
+          )
+        end
+
+        # Associations are not allowed to be submitted in their bare form (if they are submitted
+        # that way, they will be translated to either id/ids or nested attributes assignment).
+        next nil
       end
 
-      # Add `_attributes` variations for associations.
-      if self.permit_nested_attributes_assignment
-        hash_variations["#{f}_attributes"] = (
-          self.class.field_config_for(f)[:sub_fields] + ["_destroy"]
-        )
-      end
-
-      # Associations are not allowed to be submitted in their bare form (if they are submitted that
-      # way, they will be translated to either ID assignment or nested attributes assignment).
-      next nil
+      next f
     }.compact
     @_get_allowed_parameters += variations
     @_get_allowed_parameters << hash_variations
@@ -502,7 +541,7 @@ module RESTFramework::Mixins::BaseModelControllerMixin
           # Assume nested attributes assignment.
           attributes_key = "#{name}_attributes"
           data[attributes_key] = data.delete(name) unless data[attributes_key]
-        elsif id_field = RESTFramework::Utils.get_id_field(name, ref)
+        elsif id_field = RESTFramework::Utils.id_field_for(name, ref)
           # Assume id/ids assignment.
           data[id_field] = data.delete(name) unless data[id_field]
         end

--- a/lib/rest_framework/paginators/page_number_paginator.rb
+++ b/lib/rest_framework/paginators/page_number_paginator.rb
@@ -16,20 +16,21 @@ class RESTFramework::Paginators::PageNumberPaginator < RESTFramework::Paginators
     page_size = 1
 
     # Get from context, if allowed.
-    if @controller.page_size_query_param
-      if page_size = @controller.params[@controller.page_size_query_param].presence
+    if param = @controller.class.page_size_query_param
+      if page_size = @controller.params[param].presence
         page_size = page_size.to_i
       end
     end
 
     # Otherwise, get from config.
-    if !page_size && @controller.page_size
-      page_size = @controller.page_size.to_i
+    if !page_size && @controller.class.page_size
+      page_size = @controller.class.page_size.to_i
     end
 
     # Ensure we don't exceed the max page size.
-    if @controller.max_page_size && page_size > @controller.max_page_size
-      page_size = @controller.max_page_size.to_i
+    max_page_size = @controller.class.max_page_size&.to_i
+    if max_page_size && page_size > max_page_size
+      page_size = max_page_size
     end
 
     # Ensure we return at least 1.
@@ -40,7 +41,7 @@ class RESTFramework::Paginators::PageNumberPaginator < RESTFramework::Paginators
   def get_page(page_number=nil)
     # If page number isn't provided, infer from the params or use 1 as a fallback value.
     unless page_number
-      page_number = @controller&.params&.[](@controller.page_query_param&.to_sym)
+      page_number = @controller&.params&.[](@controller.class.page_query_param&.to_sym)
       if page_number.blank?
         page_number = 1
       else
@@ -59,7 +60,7 @@ class RESTFramework::Paginators::PageNumberPaginator < RESTFramework::Paginators
 
   # Wrap the serialized page with appropriate metadata. TODO: include links.
   def get_paginated_response(serialized_page)
-    page_query_param = @controller.page_query_param
+    page_query_param = @controller.class.page_query_param
     base_params = @controller.params.to_unsafe_h
     next_url = if @page_number < @total_pages
       @controller.url_for({**base_params, page_query_param => @page_number + 1})

--- a/lib/rest_framework/paginators/page_number_paginator.rb
+++ b/lib/rest_framework/paginators/page_number_paginator.rb
@@ -58,7 +58,7 @@ class RESTFramework::Paginators::PageNumberPaginator < RESTFramework::Paginators
     return @data.limit(@page_size).offset(page_index * @page_size)
   end
 
-  # Wrap the serialized page with appropriate metadata. TODO: include links.
+  # Wrap the serialized page with appropriate metadata.
   def get_paginated_response(serialized_page)
     page_query_param = @controller.class.page_query_param
     base_params = @controller.params.to_unsafe_h

--- a/lib/rest_framework/routers.rb
+++ b/lib/rest_framework/routers.rb
@@ -27,7 +27,17 @@ module ActionDispatch::Routing
         controller = mod.const_get(name)
       rescue NameError
         if fallback_reverse_pluralization
-          controller = mod.const_get(name_reverse)
+          reraise = false
+
+          begin
+            controller = mod.const_get(name_reverse)
+          rescue
+            reraise = true
+          end
+
+          if reraise
+            raise
+          end
         else
           raise
         end

--- a/lib/rest_framework/serializers/native_serializer.rb
+++ b/lib/rest_framework/serializers/native_serializer.rb
@@ -55,12 +55,12 @@ class RESTFramework::Serializers::NativeSerializer < RESTFramework::Serializers:
     return nil unless @controller
 
     if @many == true
-      controller_serializer = @controller.try(:native_serializer_plural_config)
+      controller_serializer = @controller.class.native_serializer_plural_config
     elsif @many == false
-      controller_serializer = @controller.try(:native_serializer_singular_config)
+      controller_serializer = @controller.class.native_serializer_singular_config
     end
 
-    return controller_serializer || @controller.try(:native_serializer_config)
+    return controller_serializer || @controller.class.native_serializer_config
   end
 
   # Filter a single subconfig for specific keys. By default, keys from `fields` are removed from the
@@ -114,8 +114,8 @@ class RESTFramework::Serializers::NativeSerializer < RESTFramework::Serializers:
   def filter_from_request(cfg)
     return cfg unless @controller
 
-    except_param = @controller.try(:native_serializer_except_query_param)
-    only_param = @controller.try(:native_serializer_only_query_param)
+    except_param = @controller.class.native_serializer_except_query_param
+    only_param = @controller.class.native_serializer_only_query_param
     if except_param && except = @controller.request&.query_parameters&.[](except_param).presence
       if except = except.split(",").map(&:strip).map(&:to_sym).presence
         # Filter `only`, `except` (additive), `include`, `methods`, and `serializer_methods`.
@@ -160,10 +160,10 @@ class RESTFramework::Serializers::NativeSerializer < RESTFramework::Serializers:
   def _get_associations_limit
     return @_get_associations_limit if defined?(@_get_associations_limit)
 
-    limit = @controller&.native_serializer_associations_limit
+    limit = @controller&.class&.native_serializer_associations_limit
 
     # Extract the limit from the query parameters if it's set.
-    if query_param = @controller&.native_serializer_associations_limit_query_param
+    if query_param = @controller&.class&.native_serializer_associations_limit_query_param
       if @controller.request.query_parameters.key?(query_param)
         query_limit = @controller.request.query_parameters[query_param].to_i
         if query_limit > 0
@@ -226,7 +226,7 @@ class RESTFramework::Serializers::NativeSerializer < RESTFramework::Serializers:
             #
             # # Even though we use a serializer method, if the count will later be added, then put
             # # this field into the includes_map.
-            # if @controller.native_serializer_include_associations_count
+            # if @controller.class.native_serializer_include_associations_count
             #   includes_map[f] = f.to_sym
             # end
           else
@@ -235,7 +235,7 @@ class RESTFramework::Serializers::NativeSerializer < RESTFramework::Serializers:
           end
 
           # If we need to include the association count, then add it here.
-          if @controller.native_serializer_include_associations_count
+          if @controller.class.native_serializer_include_associations_count
             method_name = "#{f}.count"
             serializer_methods[method_name] = method_name
             self.define_singleton_method(method_name) do |record|

--- a/lib/rest_framework/serializers/native_serializer.rb
+++ b/lib/rest_framework/serializers/native_serializer.rb
@@ -195,7 +195,7 @@ class RESTFramework::Serializers::NativeSerializer < RESTFramework::Serializers:
     attachment_reflections = @model.attachment_reflections
 
     fields.each do |f|
-      field_config = @controller.class.field_config_for(f)
+      field_config = @controller.class.field_configuration[f]
       next if field_config[:write_only]
 
       if f.in?(column_names)

--- a/lib/rest_framework/utils.rb
+++ b/lib/rest_framework/utils.rb
@@ -1,14 +1,12 @@
 module RESTFramework::Utils
   HTTP_VERB_ORDERING = %w(GET POST PUT PATCH DELETE OPTIONS HEAD)
 
-  # Convert `extra_actions` hash to a consistent format: `{path:, methods:, kwargs:}`, and
-  # additional metadata fields.
+  # Convert `extra_actions` hash to a consistent format: `{path:, methods:, kwargs:}`.
   #
   # If a controller is provided, labels will be added to any metadata fields.
   def self.parse_extra_actions(extra_actions, controller: nil)
     return (extra_actions || {}).map { |k, v|
       path = k
-      metadata = {}
 
       # Convert structure to path/methods/kwargs.
       if v.is_a?(Hash)  # Allow kwargs to be used to define path differently from the key.
@@ -19,11 +17,9 @@ module RESTFramework::Utils
           methods = v.delete(:method)
         end
 
-        # First, remove the route metadata.
-        metadata = v.delete(:metadata) || {}
-
-        # Add label to fields.
-        if controller && metadata[:fields]
+        # Add label to metadata fields, if any exist.
+        metadata = v[:metadata]
+        if controller && metadata&.key?(:fields)
           metadata[:fields] = metadata[:fields].map { |f|
             [f, {}]
           }.to_h if metadata[:fields].is_a?(Array)
@@ -56,8 +52,6 @@ module RESTFramework::Utils
           path: path,
           methods: methods,
           kwargs: kwargs,
-          type: :extra,
-          metadata: metadata.presence,
         }.compact,
       ]
     }.to_h
@@ -91,25 +85,28 @@ module RESTFramework::Utils
     current_levels = current_path.count("/")
     current_comparable_path = %r{^#{Regexp.quote(self.comparable_path(current_path))}(/|$)}
 
-    # Add helpful properties of the current route.
-    path_args = current_route.required_parts.map { |n| request.path_parameters[n] }
-    route_props = {
-      with_path_args: ->(r) {
-        r.format(r.required_parts.each_with_index.map { |p, i| [p, path_args[i]] }.to_h)
-      },
-    }
+    # Get current route path parameters.
+    path_params = current_route.required_parts.map { |n| request.path_parameters[n] }
 
     # Return routes that match our current route subdomain/pattern, grouped by controller. We
     # precompute certain properties of the route for performance.
-    return route_props, application_routes.routes.select { |r|
+    return application_routes.routes.select { |r|
       # We `select` first to avoid unnecessarily calculating metadata for routes we don't even want
       # to show.
       (r.defaults[:subdomain].blank? || r.defaults[:subdomain] == request.subdomain) &&
-        current_comparable_path.match?(self.comparable_path(r.path.spec.to_s)) &&
-        r.defaults[:controller].present? &&
-        r.defaults[:action].present?
+          current_comparable_path.match?(self.comparable_path(r.path.spec.to_s)) &&
+          r.defaults[:controller].present? &&
+          r.defaults[:action].present?
     }.map { |r|
       path = r.path.spec.to_s.gsub("(.:format)", "")
+
+      # Starts at the number of levels in current path, and removes the `(.:format)` at the end.
+      relative_path = path.split("/")[current_levels..]&.join("/").presence || "/"
+
+      # This path is what would need to be concatenated onto the current path to get to the
+      # destination path.
+      concat_path = relative_path.gsub(/^[^\/]*/, "").presence || "/"
+
       levels = path.count("/")
       matches_path = current_path == path
       matches_params = r.required_parts.length == current_route.required_parts.length
@@ -118,8 +115,11 @@ module RESTFramework::Utils
         route: r,
         verb: r.verb,
         path: path,
-        # Starts at the number of levels in current path, and removes the `(.:format)` at the end.
-        relative_path: path.split("/")[current_levels..]&.join("/").presence || "/",
+        path_with_params: r.format(
+          r.required_parts.each_with_index.map { |p, i| [p, path_params[i]] }.to_h,
+        ),
+        relative_path: relative_path,
+        concat_path: concat_path,
         controller: r.defaults[:controller].presence,
         action: r.defaults[:action].presence,
         matches_path: matches_path,
@@ -234,7 +234,7 @@ module RESTFramework::Utils
   end
 
   # Get a field's id/ids variation.
-  def self.get_id_field(field, reflection)
+  def self.id_field_for(field, reflection)
     if reflection.collection?
       return "#{field.singularize}_ids"
     elsif reflection.belongs_to?

--- a/test/app/controllers/api/demo/movies_controller.rb
+++ b/test/app/controllers/api/demo/movies_controller.rb
@@ -8,6 +8,9 @@ class Api::Demo::MoviesController < Api::DemoController
   }
 
   def random
+    puts "GNS: #{page_size}"
+    self.page_size = 5
+    puts "GNS: #{page_size}"
     return render_api({number: 4, message: "Chosen by fair dice roll. Guaranteed to be random."})
   end
 end

--- a/test/app/controllers/api/demo/movies_controller.rb
+++ b/test/app/controllers/api/demo/movies_controller.rb
@@ -8,9 +8,6 @@ class Api::Demo::MoviesController < Api::DemoController
   }
 
   def random
-    puts "GNS: #{page_size}"
-    self.page_size = 5
-    puts "GNS: #{page_size}"
-    return render_api({number: 4, message: "Chosen by fair dice roll. Guaranteed to be random."})
+    render_api({number: 4, message: "Chosen by fair dice roll. Guaranteed to be random."})
   end
 end

--- a/test/app/controllers/api/demo/movies_controller.rb
+++ b/test/app/controllers/api/demo/movies_controller.rb
@@ -1,3 +1,13 @@
 class Api::Demo::MoviesController < Api::DemoController
   include RESTFramework::BulkModelControllerMixin
+
+  self.extra_actions = {
+    random: {
+      methods: [:get], metadata: {description: "Get a random number.", method: "Dice roll."}
+    },
+  }
+
+  def random
+    return render_api({number: 4, message: "Chosen by fair dice roll. Guaranteed to be random."})
+  end
 end

--- a/test/app/controllers/api/plain/root_controller.rb
+++ b/test/app/controllers/api/plain/root_controller.rb
@@ -1,5 +1,5 @@
 class Api::Plain::RootController < Api::PlainController
   def root
-    api_response({message: Api::PlainController.description})
+    render_api({message: Api::PlainController.description})
   end
 end

--- a/test/app/controllers/api/root_controller.rb
+++ b/test/app/controllers/api/root_controller.rb
@@ -1,7 +1,14 @@
 class Api::RootController < ApiController
   include RESTFramework::BaseControllerMixin
 
-  self.extra_actions = {dev_test: :get, ip: :get, c: [:get, :post]}
+  self.extra_actions = {
+    dev_test: :get,
+    ip: :get,
+    c: {
+      methods: [:get, :post],
+      metadata: {gns: 5},
+    },
+  }
 
   def root
     return api_response(

--- a/test/app/controllers/api/root_controller.rb
+++ b/test/app/controllers/api/root_controller.rb
@@ -11,7 +11,7 @@ class Api::RootController < ApiController
   }
 
   def root
-    return api_response(
+    render_api(
       {
         message: "This is the test app for Rails REST Framework. There are three APIs:",
         plain_api: {
@@ -31,7 +31,7 @@ class Api::RootController < ApiController
   end
 
   def ip
-    return api_response(
+    render_api(
       {
         ip: request.ip,
         remote_ip: request.remote_ip,
@@ -45,9 +45,9 @@ class Api::RootController < ApiController
     begin
       console
     rescue NameError
-      return api_response({message: "Console not available."})
+      render_api({message: "Console not available."})
     end
 
-    return api_response({message: "Console opened."})
+    render_api({message: "Console opened."})
   end
 end

--- a/test/app/controllers/api/test/network_controller.rb
+++ b/test/app/controllers/api/test/network_controller.rb
@@ -4,6 +4,6 @@ class Api::Test::NetworkController < Api::TestController
   self.extra_actions = {test: :get}
 
   def test
-    return api_response({message: "Hello, this is your non-resourceful route!"})
+    render_api({message: "Hello, this is your non-resourceful route!"})
   end
 end

--- a/test/app/controllers/api/test/users_controller.rb
+++ b/test/app/controllers/api/test/users_controller.rb
@@ -29,6 +29,6 @@ class Api::Test::UsersController < Api::TestController
 
   def description
     record = self.get_record
-    return api_response({message: "This is record #{record.id} (#{record.login})"})
+    render_api({message: "This is record #{record.id} (#{record.login})"})
   end
 end

--- a/test/app/models/movie.rb
+++ b/test/app/models/movie.rb
@@ -12,6 +12,8 @@ class Movie < ApplicationRecord
   validates_uniqueness_of :name
   validates_numericality_of :price, greater_than: 0, allow_nil: true
 
+  attribute :default_discount, :decimal, default: 5.0
+
   def self.ransackable_attributes(*args)
     return %w(name price created_at updated_at)
   end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -39,8 +39,9 @@ class Application < Rails::Application
   config.consider_all_requests_local = !Rails.env.production?
   config.serve_static_files = true
 
-  config.cache_classes = false
-  config.action_controller.perform_caching = false
+  # Not working for some reason.
+  # lib_dir = root.join("../lib").to_s
+  # config.autoload_paths << lib_dir
 
   config.active_storage.service = :local
 

--- a/test/test/controllers/api/demo/root_controller_test.rb
+++ b/test/test/controllers/api/demo/root_controller_test.rb
@@ -2,19 +2,19 @@ require "test_helper"
 
 class Api::Demo::RootControllerTest < ActionController::TestCase
   def test_nil_fails
-    assert_raises(RESTFramework::NilPassedToAPIResponseError) do
+    assert_raises(RESTFramework::NilPassedToRenderAPIError) do
       get(:nil)
     end
   end
 
   def test_nil_json_fails
-    assert_raises(RESTFramework::NilPassedToAPIResponseError) do
+    assert_raises(RESTFramework::NilPassedToRenderAPIError) do
       get(:nil, as: :json)
     end
   end
 
   def test_nil_xml_fails
-    assert_raises(RESTFramework::NilPassedToAPIResponseError) do
+    assert_raises(RESTFramework::NilPassedToRenderAPIError) do
       get(:nil, as: :xml)
     end
   end


### PR DESCRIPTION
- [x] OpenAPI for `OPTIONS` response.
- [x] Figure out if I want to keep using `get_` getters for controller instance methods. It is kinda un-rubyish however it's nice because it helps avoid clashing with action method names which should never be prefixed with `get_` because that's what HTTP verbs are for. Potentially revert `get_serializer_class` to `serializer_class` change..
- [x] Move as many class attributes from `RRF_BASE_MODEL_INSTANCE_CONFIG` into `RRF_BASE_MODEL_CONFIG`; avoid polluting controller instance namespace.
- [x] Resolve TODOs.
- [x] Review controller instance methods; determine if any should be private (`_` prefixed).